### PR TITLE
add yopmail.com

### DIFF
--- a/lib/hostnames.ts
+++ b/lib/hostnames.ts
@@ -9,6 +9,7 @@ export default {
     "tempail.com",
     "zomro.com",
     "guerrillamail.com",
-    "namesilo.com"
+    "namesilo.com",
+    "yopmail.com"
   ])
 };


### PR DESCRIPTION
yopmail.com provides disposable e-mail address.
pattern: ‘any-name-of-your-choice’@yopmail.com